### PR TITLE
Feature/erase

### DIFF
--- a/SSD/SSD.vcxproj
+++ b/SSD/SSD.vcxproj
@@ -130,6 +130,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="erase.cpp" />
     <ClCompile Include="main.cpp">
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'"> %(AdditionalOptions)</AdditionalOptions>
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'"> %(AdditionalOptions)</AdditionalOptions>
@@ -143,6 +144,7 @@
     <ClCompile Include="write.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="erase.h" />
     <ClInclude Include="read.h" />
     <ClInclude Include="ssd.h" />
     <ClInclude Include="write.h" />

--- a/SSD/SSD.vcxproj
+++ b/SSD/SSD.vcxproj
@@ -137,8 +137,8 @@
     </ClCompile>
     <ClCompile Include="ssd.cpp" />
     <ClCompile Include="SSD_test.cpp">
-      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'"> %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'"> %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">  %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">  %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <ClCompile Include="read.cpp" />
     <ClCompile Include="write.cpp" />

--- a/SSD/SSD.vcxproj.filters
+++ b/SSD/SSD.vcxproj.filters
@@ -33,6 +33,9 @@
     <ClCompile Include="write.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
+    <ClCompile Include="erase.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ssd.h">
@@ -42,6 +45,9 @@
       <Filter>헤더 파일</Filter>
     </ClInclude>
     <ClInclude Include="read.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="erase.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
   </ItemGroup>

--- a/SSD/SSD_test.cpp
+++ b/SSD/SSD_test.cpp
@@ -239,6 +239,14 @@ TEST_F(SSDFixture, EraseTest_WriteAndErase)
 
 	bool ret = mySsd.run("E 4 10");
 	EXPECT_EQ(ret, true);
+
+	for (int i = 4; i < 14; i++)
+	{
+		std::string command = "R ";
+		command.append(std::to_string(i));
+		mySsd.run(command);
+		validCheckOfOutputFile("0x00000000");
+	}
 }
 
 TEST_F(SSDFixture, EraseTest_WriteAndEraseWithSizeZero)

--- a/SSD/SSD_test.cpp
+++ b/SSD/SSD_test.cpp
@@ -223,3 +223,37 @@ TEST_F(SSDFixture, EraseTest_InValidLBA)
 	bool ret = mySsd.run("E 100 10");
 	EXPECT_EQ(ret, false);
 }
+
+TEST_F(SSDFixture, EraseTest_WriteAndErase)
+{
+	mySsd.run("W 0 0x12345678");
+	mySsd.run("W 1 0xCCCCCCCC");
+	mySsd.run("W 2 0x1234ABCD");
+	mySsd.run("W 3 0xCCCCCCCC");
+	mySsd.run("W 4 0x00000000");
+	mySsd.run("W 5 0x5555AAAA");
+	mySsd.run("W 6 0xCCCCCCCC");
+
+	bool ret = mySsd.run("E 4 10");
+	EXPECT_EQ(ret, true);
+}
+
+TEST_F(SSDFixture, EraseTest_WriteAndEraseWithSizeZero)
+{
+	mySsd.run("W 97 0x12345678");
+	mySsd.run("W 98 0xCCCCCCCC");
+	mySsd.run("W 99 0x1234ABCD");
+
+	bool ret = mySsd.run("E 1 0");
+	EXPECT_EQ(ret, true);
+}
+
+TEST_F(SSDFixture, EraseTest_WriteAndEraseWithSize1)
+{
+	mySsd.run("W 97 0x12345670");
+	mySsd.run("W 98 0xCCCCCCC0");
+	mySsd.run("W 99 0x1234ABC0");
+
+	bool ret = mySsd.run("E 1 1");
+	EXPECT_EQ(ret, true);
+}

--- a/SSD/SSD_test.cpp
+++ b/SSD/SSD_test.cpp
@@ -185,3 +185,39 @@ TEST_F(SSDFixture, WriteFileUpdateChangeMapValueTest)
 	std::getline(file, output);
 	EXPECT_EQ("2 0xDDDDDDDD", output);
 }
+
+TEST_F(SSDFixture, SSDTest_EraseValidSizeCommand)
+{
+	bool ret = mySsd.run("E 0 10");
+	EXPECT_EQ(ret, true);
+}
+
+TEST_F(SSDFixture, SSDTest_EraseInValidSizeCommand)
+{
+	bool ret = mySsd.run("E 0 -1");
+	EXPECT_EQ(ret, true);
+}
+
+TEST_F(SSDFixture, SSDTest_EraseInValidSizeCommand)
+{
+	bool ret = mySsd.run("E 0 0");
+	EXPECT_EQ(ret, true);
+}
+
+TEST_F(SSDFixture, SSDTest_EraseInValidSizeCommand)
+{
+	bool ret = mySsd.run("E 0 11");
+	EXPECT_EQ(ret, true);
+}
+
+TEST_F(SSDFixture, SSDTest_EraseValidSizeButOutOfRange)
+{
+	bool ret = mySsd.run("D 95 10");
+	EXPECT_EQ(ret, false);
+}
+
+TEST_F(SSDFixture, SSDTest_EraseInValidLBA)
+{
+	bool ret = mySsd.run("D 100 10");
+	EXPECT_EQ(ret, false);
+}

--- a/SSD/SSD_test.cpp
+++ b/SSD/SSD_test.cpp
@@ -203,12 +203,14 @@ TEST_F(SSDFixture, EraseTest_InValidSize)
 {
 	bool ret = mySsd.run("E 0 -1");
 	EXPECT_EQ(ret, false);
+	validCheckOfOutputFile("ERROR");
 }
 
 TEST_F(SSDFixture, EraseTest_InValidSize2)
 {
 	bool ret = mySsd.run("E 0 11");
 	EXPECT_EQ(ret, false);
+	validCheckOfOutputFile("ERROR");
 }
 
 TEST_F(SSDFixture, EraseTest_ValidSizeButOutOfRange)
@@ -222,6 +224,7 @@ TEST_F(SSDFixture, EraseTest_InValidLBA)
 {
 	bool ret = mySsd.run("E 100 10");
 	EXPECT_EQ(ret, false);
+	validCheckOfOutputFile("ERROR");
 }
 
 TEST_F(SSDFixture, EraseTest_WriteAndErase)

--- a/SSD/SSD_test.cpp
+++ b/SSD/SSD_test.cpp
@@ -1,4 +1,4 @@
-#include "gmock/gmock.h"
+﻿#include "gmock/gmock.h"
 #include <string>
 #include <map>
 #include <fstream>
@@ -186,25 +186,26 @@ TEST_F(SSDFixture, WriteFileUpdateChangeMapValueTest)
 	EXPECT_EQ("2 0xDDDDDDDD", output);
 }
 
-TEST_F(SSDFixture, SSDTest_EraseValidSizeCommand)
+TEST_F(SSDFixture, SSDTest_EraseValidSizeTest)
 {
 	bool ret = mySsd.run("E 0 10");
 	EXPECT_EQ(ret, true);
 }
 
-TEST_F(SSDFixture, SSDTest_EraseInValidSizeCommand)
+TEST_F(SSDFixture, SSDTest_EraseInValidSizeTest)
 {
 	bool ret = mySsd.run("E 0 -1");
 	EXPECT_EQ(ret, true);
 }
 
-TEST_F(SSDFixture, SSDTest_EraseInValidSizeCommand)
+TEST_F(SSDFixture, SSDTest_EraseValidSizeTest)
 {
+	// Size 0은 에러는 아니다. 아무런 동작을 하지 않는다.
 	bool ret = mySsd.run("E 0 0");
 	EXPECT_EQ(ret, true);
 }
 
-TEST_F(SSDFixture, SSDTest_EraseInValidSizeCommand)
+TEST_F(SSDFixture, SSDTest_EraseInValidSizeTest2)
 {
 	bool ret = mySsd.run("E 0 11");
 	EXPECT_EQ(ret, true);
@@ -212,12 +213,13 @@ TEST_F(SSDFixture, SSDTest_EraseInValidSizeCommand)
 
 TEST_F(SSDFixture, SSDTest_EraseValidSizeButOutOfRange)
 {
-	bool ret = mySsd.run("D 95 10");
+	// 99까지만 처리함.
+	bool ret = mySsd.run("E 95 10");
 	EXPECT_EQ(ret, false);
 }
 
 TEST_F(SSDFixture, SSDTest_EraseInValidLBA)
 {
-	bool ret = mySsd.run("D 100 10");
+	bool ret = mySsd.run("E 100 10");
 	EXPECT_EQ(ret, false);
 }

--- a/SSD/SSD_test.cpp
+++ b/SSD/SSD_test.cpp
@@ -186,39 +186,39 @@ TEST_F(SSDFixture, WriteFileUpdateChangeMapValueTest)
 	EXPECT_EQ("2 0xDDDDDDDD", output);
 }
 
-TEST_F(SSDFixture, SSDTest_EraseValidSizeTest)
+TEST_F(SSDFixture, EraseTest_ValidSize)
 {
 	bool ret = mySsd.run("E 0 10");
 	EXPECT_EQ(ret, true);
 }
 
-TEST_F(SSDFixture, SSDTest_EraseInValidSizeTest)
-{
-	bool ret = mySsd.run("E 0 -1");
-	EXPECT_EQ(ret, true);
-}
-
-TEST_F(SSDFixture, SSDTest_EraseValidSizeTest)
+TEST_F(SSDFixture, EraseTest_ValidSize2)
 {
 	// Size 0은 에러는 아니다. 아무런 동작을 하지 않는다.
 	bool ret = mySsd.run("E 0 0");
 	EXPECT_EQ(ret, true);
 }
 
-TEST_F(SSDFixture, SSDTest_EraseInValidSizeTest2)
+TEST_F(SSDFixture, EraseTest_InValidSize)
 {
-	bool ret = mySsd.run("E 0 11");
-	EXPECT_EQ(ret, true);
-}
-
-TEST_F(SSDFixture, SSDTest_EraseValidSizeButOutOfRange)
-{
-	// 99까지만 처리함.
-	bool ret = mySsd.run("E 95 10");
+	bool ret = mySsd.run("E 0 -1");
 	EXPECT_EQ(ret, false);
 }
 
-TEST_F(SSDFixture, SSDTest_EraseInValidLBA)
+TEST_F(SSDFixture, EraseTest_InValidSize2)
+{
+	bool ret = mySsd.run("E 0 11");
+	EXPECT_EQ(ret, false);
+}
+
+TEST_F(SSDFixture, EraseTest_ValidSizeButOutOfRange)
+{
+	// 99까지만 처리함.
+	bool ret = mySsd.run("E 95 10");
+	EXPECT_EQ(ret, true);
+}
+
+TEST_F(SSDFixture, EraseTest_InValidLBA)
 {
 	bool ret = mySsd.run("E 100 10");
 	EXPECT_EQ(ret, false);

--- a/SSD/erase.cpp
+++ b/SSD/erase.cpp
@@ -16,13 +16,13 @@ bool EraseSSD::execute(std::map<int, std::string>& nand, int lba, const std::str
 			if (lba + i >= 100) break;
 			auto ret = nand.find(lba+i);
 			if (ret != nand.end()) {
-				nand.erase(lba);
+				nand.erase(lba+i);
 			}
 		}
 
 		if (!updateSSDNandFile(nand)) {
 			return false;
-}
+		}
 	}
 
 	return true;
@@ -60,6 +60,7 @@ bool EraseSSD::updateSSDNandFile(std::map<int, std::string>& nand) {
 	}
 
 	for (const auto& pair : nand) {
+		std::cout << "key : " << pair.first << ", value : " << pair.second << std::endl;
 		outFile << pair.first << " " << pair.second << std::endl;
 	}
 

--- a/SSD/erase.cpp
+++ b/SSD/erase.cpp
@@ -2,6 +2,7 @@
 
 bool EraseSSD::execute(std::map<int, std::string>& nand, int lba, const std::string& size) {
 	bool ret = false;
+	int eraseSize = 0;
 	if (ret = GetSizeAfterCheckInvalidSizeOrNot(size, &eraseSize))
 	{
 		std::ofstream outputFile(outputfilePath, std::ios::trunc);

--- a/SSD/erase.cpp
+++ b/SSD/erase.cpp
@@ -1,4 +1,4 @@
-#include "erase.h"
+ï»¿#include "erase.h"
 
 bool EraseSSD::execute(std::map<int, std::string>& nand, int lba, const std::string& size) {
 	bool ret = false;
@@ -36,7 +36,7 @@ bool EraseSSD::GetSizeAfterCheckInvalidSizeOrNot(const std::string& sizeStr, int
 	try {
 		size = std::stoi(sizeStr);
 
-		// 0Àº ¿¡·¯°¡ ¾Æ´Ï¶ó°í ÇßÀ½.
+		// 0ì€ ì—ëŸ¬ê°€ ì•„ë‹ˆë¼ê³  í–ˆìŒ.
 		if (size < 0 || size > 10) {
 			ret = true;
 		}

--- a/SSD/erase.cpp
+++ b/SSD/erase.cpp
@@ -60,7 +60,6 @@ bool EraseSSD::updateSSDNandFile(std::map<int, std::string>& nand) {
 	}
 
 	for (const auto& pair : nand) {
-		std::cout << "key : " << pair.first << ", value : " << pair.second << std::endl;
 		outFile << pair.first << " " << pair.second << std::endl;
 	}
 

--- a/SSD/erase.cpp
+++ b/SSD/erase.cpp
@@ -1,0 +1,68 @@
+#include "erase.h"
+
+bool EraseSSD::execute(std::map<int, std::string>& nand, int lba, const std::string& size) {
+	bool ret = false;
+	if (ret = GetSizeAfterCheckInvalidSizeOrNot(size, &eraseSize))
+	{
+		std::ofstream outputFile(outputfilePath, std::ios::trunc);
+		outputFile << "ERROR";
+		return false;
+	}
+	
+	if (eraseSize != 0)
+	{
+		for (int i = 0; i < eraseSize; i++)
+		{
+			if (lba + i >= 100) break;
+			auto ret = nand.find(lba+i);
+			if (ret != nand.end()) {
+				nand.erase(lba);
+			}
+		}
+
+		if (!updateSSDNandFile(nand)) {
+			return false;
+}
+	}
+
+	return true;
+}
+
+bool EraseSSD::GetSizeAfterCheckInvalidSizeOrNot(const std::string& sizeStr, int* getValidSize)
+{
+	int size = 0;
+	bool ret = false;
+
+	try {
+		size = std::stoi(sizeStr);
+
+		// 0은 에러가 아니라고 했음.
+		if (size < 0 || size > 10) {
+			ret = true;
+		}
+	}
+	catch (const std::invalid_argument& e) {
+		ret = true;
+	}
+	catch (const std::out_of_range& e) {
+		ret = true;
+	}
+
+	*getValidSize = size;
+	return ret;
+}
+
+bool EraseSSD::updateSSDNandFile(std::map<int, std::string>& nand) {
+	std::ofstream outFile(nandfilePath);
+
+	if (!outFile.is_open()) {
+		return false;
+	}
+
+	for (const auto& pair : nand) {
+		outFile << pair.first << " " << pair.second << std::endl;
+	}
+
+	outFile.close();
+	return true;
+}

--- a/SSD/erase.h
+++ b/SSD/erase.h
@@ -16,7 +16,6 @@ private:
 
     const std::string outputfilePath = "ssd_output.txt";
     const std::string nandfilePath = "ssd_nand.txt";
-    int eraseSize = 0;
 };
 
 #endif

--- a/SSD/erase.h
+++ b/SSD/erase.h
@@ -1,0 +1,22 @@
+#ifndef ERASESDD_H
+#define ERASESDD_H
+
+#include <iostream>
+#include <fstream>
+#include <map>
+#include <string>
+
+class EraseSSD {
+public:
+    bool execute(std::map<int, std::string>& nand, int lba, const std::string& size);
+
+private:
+    bool updateSSDNandFile(std::map<int, std::string>& nand);
+    bool GetSizeAfterCheckInvalidSizeOrNot(const std::string& sizeStr, int* getValidSize);
+
+    const std::string outputfilePath = "ssd_output.txt";
+    const std::string nandfilePath = "ssd_nand.txt";
+    int eraseSize = 0;
+};
+
+#endif

--- a/SSD/ssd.cpp
+++ b/SSD/ssd.cpp
@@ -43,7 +43,11 @@ SSD::run(string input)
 	}
 	else if (commandStr == "R")
 	{
-		myRead.execute(ssdMap, lba);
+		ret = myRead.execute(ssdMap, lba);
+	}
+	else if (commandStr == "E")
+	{
+		ret = myErase.execute(ssdMap, lba, dataStr);
 	}
 
 	return ret;
@@ -52,7 +56,7 @@ SSD::run(string input)
 bool
 SSD::IsInvalidCommand(string command)
 {
-	return !((command == "W") || (command == "R"));
+	return !((command == "W") || (command == "R") || (command == "E"));
 
 }
 

--- a/SSD/ssd.h
+++ b/SSD/ssd.h
@@ -3,6 +3,7 @@
 
 #include "write.h"
 #include "read.h"
+#include "erase.h"
 
 class SSD {
 public:
@@ -14,6 +15,7 @@ public:
 private:
 	WriteSSD myWrite;
 	ReadSSD myRead;
+	EraseSSD myErase;
 
 	const std::string outputfilePath = "ssd_output.txt";
 	const std::string nandfilePath = "ssd_nand.txt";


### PR DESCRIPTION
SSD에서 erase 처리하는 부분 구현했습니다.
1. size 에러 처리 : 음수, 10 초과
2. 2. size 0은 아무런 동작하지 않기. 에러는 아님.
3. 삭제하면 map.erase() 호출하여 날리기.
4. map 동작을 마치면 ssd_nand.txt 파일에 업데이트하기