### PR TITLE
Refactor) NANDFileHandler 추가 하여 상속을 통한 중복 코드를 제거

### DIFF
--- a/SSD/SSD.vcxproj
+++ b/SSD/SSD.vcxproj
@@ -149,6 +149,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="erase.h" />
+    <ClInclude Include="nand.h" />
     <ClInclude Include="read.h" />
     <ClInclude Include="ssd.h" />
     <ClInclude Include="write.h" />

--- a/SSD/SSD.vcxproj.filters
+++ b/SSD/SSD.vcxproj.filters
@@ -56,5 +56,8 @@
     <ClInclude Include="erase.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
+    <ClInclude Include="nand.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/SSD/erase.cpp
+++ b/SSD/erase.cpp
@@ -52,18 +52,3 @@ bool EraseSSD::GetSizeAfterCheckInvalidSizeOrNot(const std::string& sizeStr, int
 	*getValidSize = size;
 	return ret;
 }
-
-bool EraseSSD::updateSSDNandFile(std::map<int, std::string>& nand) {
-	std::ofstream outFile(nandfilePath);
-
-	if (!outFile.is_open()) {
-		return false;
-	}
-
-	for (const auto& pair : nand) {
-		outFile << pair.first << " " << pair.second << std::endl;
-	}
-
-	outFile.close();
-	return true;
-}

--- a/SSD/erase.h
+++ b/SSD/erase.h
@@ -1,21 +1,16 @@
 #ifndef ERASESDD_H
 #define ERASESDD_H
 
-#include <iostream>
-#include <fstream>
-#include <map>
-#include <string>
+#include "nand.h"
 
-class EraseSSD {
+class EraseSSD : NANDFileHandler {
 public:
     bool execute(std::map<int, std::string>& nand, int lba, const std::string& size);
 
 private:
-    bool updateSSDNandFile(std::map<int, std::string>& nand);
     bool GetSizeAfterCheckInvalidSizeOrNot(const std::string& sizeStr, int* getValidSize);
 
     const std::string outputfilePath = "ssd_output.txt";
-    const std::string nandfilePath = "ssd_nand.txt";
 };
 
 #endif

--- a/SSD/erase.h
+++ b/SSD/erase.h
@@ -3,7 +3,7 @@
 
 #include "nand.h"
 
-class EraseSSD : NANDFileHandler {
+class EraseSSD : public NANDFileHandler {
 public:
     bool execute(std::map<int, std::string>& nand, int lba, const std::string& size);
 

--- a/SSD/nand.h
+++ b/SSD/nand.h
@@ -1,0 +1,26 @@
+#pragma once
+#include <iostream>
+#include <fstream>
+#include <map>
+#include <string>
+
+class NANDFileHandler {
+public:
+    bool updateSSDNandFile(std::map<int, std::string>& nand) {
+        std::ofstream outFile(nandfilePath);
+
+        if (!outFile.is_open()) {
+            return false;
+        }
+
+        for (const auto& pair : nand) {
+            outFile << pair.first << " " << pair.second << std::endl;
+        }
+
+        outFile.close();
+        return true;
+    }
+
+private:
+    const std::string nandfilePath = "ssd_nand.txt";
+};

--- a/SSD/write.cpp
+++ b/SSD/write.cpp
@@ -15,19 +15,3 @@ bool WriteSSD::execute(std::map<int, std::string>& nand, int lba, const std::str
 
 	return true;
 }
-
-bool WriteSSD::updateSSDNandFile(std::map<int, std::string>& nand) {
-	std::ofstream outFile(PATH_SSD_NAND_FILE);
-
-	if (!outFile.is_open()) {
-		return false;
-	}
-
-	for (const auto& pair : nand) {
-		outFile << pair.first << " " << pair.second << std::endl;
-	}
-
-	outFile.close();
-	return true;
-}
-

--- a/SSD/write.h
+++ b/SSD/write.h
@@ -1,19 +1,13 @@
 #ifndef WRITESDD_H
 #define WRITESDD_H
 
-#include <iostream>
-#include <fstream>
-#include <map>
-#include <string>
+#include "nand.h"
 
-#define PATH_SSD_NAND_FILE  "ssd_nand.txt"
-
-class WriteSSD {
+class WriteSSD : NANDFileHandler {
 public:
     bool execute(std::map<int, std::string>& nand, int lba, const std::string& data);
 
 private:
-    bool updateSSDNandFile(std::map<int, std::string>& nand);
 };
 
 #endif

--- a/SSD/write.h
+++ b/SSD/write.h
@@ -3,7 +3,7 @@
 
 #include "nand.h"
 
-class WriteSSD : NANDFileHandler {
+class WriteSSD : public NANDFileHandler {
 public:
     bool execute(std::map<int, std::string>& nand, int lba, const std::string& data);
 


### PR DESCRIPTION
NANDFileHandler 를 상속받도록 EraseSSD 와 WriteSSD 를 리팩토링하였습니다. PR 부탁드립니다.

1. 코드 재사용성 증가 (Code Reusability)
NANDFileHandler 클래스에서 updateSSDNandFile 메서드를 하나의 공통된 방법으로 파일을 처리할 수 있도록 구현했습니다. 이로 인해 WriteSSD와 EraseSSD 클래스가 파일 처리 로직을 직접 구현할 필요가 없어졌습니다.

WriteSSD와 EraseSSD는 공통의 상위 클래스인 NANDFileHandler를 상속받기 때문에, 파일 처리 로직이 중복되지 않고 재사용됩니다.

이 방식은 향후 다른 SSD 관련 클래스가 추가될 때, 파일 처리 기능을 재사용할 수 있어 코드의 확장성이 크게 향상됩니다.

2. 유지보수 용이성 (Maintainability)
파일 처리 로직이 NANDFileHandler 클래스에 집중되어 있기 때문에, NAND 파일 처리 방식에 변경이 있을 때 해당 로직을 NANDFileHandler에서만 수정하면 됩니다. 이를 통해 파일 처리 관련 수정이 다른 클래스들에 영향을 미치지 않으며, 수정 범위가 명확해집니다.

예를 들어, 파일 경로나 형식이 바뀌더라도 NANDFileHandler만 수정하면 되므로 유지보수가 간편해집니다.

3. SRP (Single Responsibility Principle) 준수
NANDFileHandler는 오직 NAND 파일 처리만을 담당하고, WriteSSD와 EraseSSD는 각각의 SSD 작업에만 집중합니다. 각각의 클래스가 **단일 책임 원칙(SRP)**을 준수하게 되어, 코드가 명확하고 테스트 및 수정이 용이해집니다.

예를 들어, WriteSSD는 데이터를 쓰는 역할만 하며, EraseSSD는 데이터를 지우는 작업을 수행하고, 파일 처리 부분은 NANDFileHandler가 담당합니다.

4. 확장성 (Scalability)
SSD와 관련된 다양한 작업을 수행하는 클래스가 추가되더라도, NANDFileHandler 클래스는 그대로 두고 새로운 클래스에서 상속을 받아 필요한 작업을 구현할 수 있습니다.

예를 들어, FormatSSD라는 새로운 클래스가 추가된다면, 그 클래스도 NANDFileHandler를 상속받아 파일 처리를 공통으로 활용할 수 있습니다. 이는 코드가 중복되지 않고, 쉽게 확장할 수 있게 만듭니다.

5. 클래스 간 역할 분리 (Separation of Concerns)
WriteSSD와 EraseSSD 클래스는 각자의 목적에 맞게 잘 분리되어 있습니다. WriteSSD는 데이터를 쓰는 작업만, EraseSSD는 데이터를 지우는 작업만 처리합니다. 파일 처리 로직은 NANDFileHandler로 분리되어, 각 클래스가 자신의 역할에만 집중할 수 있습니다.

이는 시스템 설계를 더 직관적으로 만들고, 각 클래스가 무엇을 하는지 명확하게 구분되므로 코드 가독성이 높아집니다.

6. 클래스 상속을 통한 코드 간결성 (Class Inheritance for Simplicity)
WriteSSD와 EraseSSD가 NANDFileHandler를 상속받음으로써, 파일 처리 메서드 updateSSDNandFile을 따로 구현할 필요 없이 상속받은 메서드를 사용할 수 있습니다.

상속을 사용하면 중복을 줄일 수 있고, 새로운 클래스가 생겨날 때마다 파일 처리 메서드를 중복 작성할 필요 없이 NANDFileHandler를 상속받기만 하면 되므로 코드가 간결해집니다.

7. 상수 관리의 중앙화 (Centralized Constant Management)
NANDFileHandler 클래스 내에서 nandfilePath라는 상수를 관리하게 되어 파일 경로와 같은 중요한 값들이 한 곳에서 관리됩니다. 이를 통해 향후 경로 변경이 필요할 때, 한 곳만 수정하면 전체 시스템에서 반영되므로 관리가 편리합니다